### PR TITLE
https://github.com/OpenPaaS-Suite/esn/issues/36 forces CI to fetch the newest packages when running 'npm install'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
       }
 
       steps {
-        sh 'npm install'
+        sh 'npm install -f'
         sh 'npm run lint'
         sh 'npm run test'
       }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:10-buster
+
+RUN apt-get update
+RUN apt-get install -y firefox-esr
+
+ENV MOZ_FORCE_DISABLE_E10S=true


### PR DESCRIPTION
Partially resolve https://github.com/OpenPaaS-Suite/esn/issues/36﻿
